### PR TITLE
Added option to run the backup step by step

### DIFF
--- a/remotecli/Command/Backup.php
+++ b/remotecli/Command/Backup.php
@@ -34,10 +34,11 @@ class Backup extends AbstractCommand
 	{
 		$this->assertConfigured($input);
 
-		$testModel   = new TestModel();
-		$backupModel = new BackupModel();
-		$downloadModel      = new Download();
-		$mustDownload = $input->getBool('download', false);
+		$testModel      = new TestModel();
+		$backupModel    = new BackupModel();
+		$downloadModel  = new Download();
+
+		$mustDownload   = $input->getBool('download', false);
 
 		/**
 		 * DO NOT DELETE!

--- a/remotecli/Model/Backup.php
+++ b/remotecli/Model/Backup.php
@@ -72,7 +72,7 @@ class Backup
 			$archive        = $result['archive'];
 
 			// Keep the backup loop running until we're done OR run step by step if asked so
-			$keep_running = $result['hasRan'];
+			$keep_running = $result['hasRun'];
 
 			// If running step by step, immediately break
 			if ($single_step)
@@ -188,7 +188,7 @@ class Backup
 		$output->info("Domain  : {$data->body->data->Domain}");
 		$output->info("Step    : {$data->body->data->Step}");
 		$output->info("Substep : {$data->body->data->Substep}");
-		$output->debug("HasRan : {$data->body->data->HasRun}");
+		$output->debug("HasRun : {$data->body->data->HasRun}");
 
 		if (!empty($data->body->data->Warnings))
 		{
@@ -204,7 +204,7 @@ class Backup
 			'backupRecordID' => $backupRecordID,
 			'backupID'       => $backupID,
 			'archive'        => $archive,
-			'hasRan'         => isset($data->body->data->HasRun) && $data->body->data->HasRun
+			'hasRun'         => (isset($data->body->data->HasRun) && $data->body->data->HasRun)
 		];
 	}
 }

--- a/remotecli/Model/Backup.php
+++ b/remotecli/Model/Backup.php
@@ -29,8 +29,8 @@ class Backup
 	 */
 	public function backup(Cli $input, Output $output, Options $options)
 	{
-		$api = new Api($options, $output);
-		$profile        = (int) ($input->getInt('profile', 1));
+		$api            = new Api($options, $output);
+		$profile        = $input->getInt('profile', 1);
 		$description    = $input->getString('description', "Remote backup");
 		$comment        = $input->getHtml('comment', '');
 		$backupRecordID = 0;

--- a/remotecli/Model/Backup.php
+++ b/remotecli/Model/Backup.php
@@ -188,6 +188,7 @@ class Backup
 		$output->info("Domain  : {$data->body->data->Domain}");
 		$output->info("Step    : {$data->body->data->Step}");
 		$output->info("Substep : {$data->body->data->Substep}");
+		$output->debug("HasRan : {$data->body->data->HasRun}");
 
 		if (!empty($data->body->data->Warnings))
 		{

--- a/remotecli/Model/Backup.php
+++ b/remotecli/Model/Backup.php
@@ -49,11 +49,18 @@ class Backup
 		$data = $api->doQuery('startBackup', $config);
 
 		// Keep the backup loop running until we're done OR run step by step if asked so
-		while (
-			(isset($data->body->data->HasRun) && $data->body->data->HasRun) ||
-			$single_step
-		)
+		$keep_running = true;
+
+		while ($keep_running)
 		{
+			$keep_running = (isset($data->body->data->HasRun) && $data->body->data->HasRun);
+
+			// If running step by step, immediately break
+			if ($single_step)
+			{
+				$keep_running = false;
+			}
+
 			if ($data->body->status != 200)
 			{
 				throw new RemoteError('Error ' . $data->body->status . ": " . $data->body->data);

--- a/remotecli/Model/Backup.php
+++ b/remotecli/Model/Backup.php
@@ -31,9 +31,14 @@ class Backup
 	{
 		$api            = new Api($options, $output);
 		$single_step    = $input->getInt('single_step', 0);
+		$step           = $input->getInt('step', 0);
+		$backupID       = $input->getCmd('backupid', '');
 		$profile        = $input->getInt('profile', 1);
 		$description    = $input->getString('description', "Remote backup");
 		$comment        = $input->getHtml('comment', '');
+
+		$backupRecordID = '';
+		$archive        = '';
 
 		$config = [
 			'profile'     => $profile,
@@ -41,13 +46,16 @@ class Backup
 			'comment'     => $comment,
 		];
 
-		$result = $this->handleQuery($api, 'startBackup', $config, $output);
+		if (!$step)
+		{
+			$result = $this->handleQuery($api, 'startBackup', $config, $output);
 
-		$backupRecordID = $result['backupRecordID'];
-		$backupID       = $result['backupID'];
-		$archive        = $result['archive'];
+			$backupRecordID = $result['backupRecordID'];
+			$backupID       = $result['backupID'];
+			$archive        = $result['archive'];
+		}
 
-		$params = array();
+		$params = [];
 
 		if (!empty($backupID))
 		{


### PR DESCRIPTION
Added an option to the backup command to return immediately after running the first step (or the first two if we have to start a new backup).
This new feature will be used by our MainWP integration, where we use RemoteCLI code to interact with JSON API.  

This PR is completely backward compatible, no changes are required to existing scripts.