### PR TITLE
Divide start and step backups into different methods

### DIFF
--- a/remotecli/Command/Backup.php
+++ b/remotecli/Command/Backup.php
@@ -9,6 +9,7 @@
 namespace Akeeba\RemoteCLI\Command;
 
 
+use Akeeba\RemoteCLI\Exception\NoBackupID;
 use Akeeba\RemoteCLI\Input\Cli;
 use Akeeba\RemoteCLI\Model\Backup as BackupModel;
 use Akeeba\RemoteCLI\Model\Download;
@@ -85,4 +86,41 @@ class Backup extends AbstractCommand
 		}
 	}
 
+
+	public function startBackup(Cli $input, Output $output)
+	{
+		$this->assertConfigured($input);
+
+		$testModel   = new TestModel();
+		$backupModel = new BackupModel();
+
+		// Find the best options to connect to the API
+		$options = $this->getApiOptions($input);
+		$options = $testModel->getBestOptions($input, $output, $options);
+
+		// Take a backup
+		$backupModel->startBackup($input, $output, $options);
+	}
+
+	public function stepBackup(Cli $input, Output $output)
+	{
+		$this->assertConfigured($input);
+
+		$backupID = $input->getString('backupid');
+
+		if (!$backupID)
+		{
+			throw new NoBackupID();
+		}
+
+		$testModel   = new TestModel();
+		$backupModel = new BackupModel();
+
+		// Find the best options to connect to the API
+		$options = $this->getApiOptions($input);
+		$options = $testModel->getBestOptions($input, $output, $options);
+
+		// Take a backup
+		$backupModel->stepBackup($output, $options, $backupID);
+	}
 }

--- a/remotecli/Model/Backup.php
+++ b/remotecli/Model/Backup.php
@@ -182,11 +182,14 @@ class Backup
 			$progress = $data->body->data->Progress;
 		}
 
+		$hasRun = isset($data->body->data->HasRun) && $data->body->data->HasRun;
+
 		$output->header('Got backup tick');
 		$output->info("Progress: {$progress}%");
 		$output->info("Domain  : {$data->body->data->Domain}");
 		$output->info("Step    : {$data->body->data->Step}");
 		$output->info("Substep : {$data->body->data->Substep}");
+		$output->debug("HasRun  : {$hasRun}");
 
 		if (!empty($data->body->data->Warnings))
 		{


### PR DESCRIPTION
Divided current code into two different methods to start and step a backup. In this way we can exactly control which part of the backup to invoke.  
This PR is completely B/C compatible.  

Please note that two methods have been added to the `Backup` command, on top of the existing one. In this way we can include the class and start/step a backup without duplicating code. The best thing should be using the Model, but it requires some info that are produced by the Controller class inside protected methods. I do not feel comfortable to change current logic just for this.  
Moreover, they are not available as CLI commands, so they are totally hidden to end user, but for internal use only. I think it's a good compromise.